### PR TITLE
GDB pretty printers for Utf32Str/Utf32String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `trim_end` character boundary panic when processing 4-byte characters. By [@syrflover].
 - Documentation typos on `WideCString` type alias
 
+### Added
+- Added GDB pretty printers for `Utf32String` and `Utf32Str`. You can load them from `gdb/widestring.py`.
+
 ## [1.2.0] - 2024-03-15 <a name="1.2.0"></a>
 ### Changed
 - Minor restructing of included license file locations to be more consistent with crates ecosystem.

--- a/gdb/widestring.py
+++ b/gdb/widestring.py
@@ -1,0 +1,48 @@
+import gdb
+import traceback
+import gdb.printing
+import unicodedata
+
+def codepoints_to_rust_string(data_ptr, length: int) -> str:
+    def to_rust_string(cp: int) -> str:
+        c = chr(cp)
+        # Surrogate or private use.
+        if unicodedata.category(c) in ('Cs', 'Co'):
+            return f"\\u{{{cp:04x}}}" if cp <= 0xffff else f"\\U{{{cp:08x}}}"
+        if c in '\\"':
+            return "\\" + c
+        return c
+    codepoints = (int((data_ptr + i).dereference()) for i in range(length))
+    return '"' + ''.join(to_rust_string(cp) for cp in codepoints) + '"'
+
+class Utf32StrPrinter:
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        try:
+            ptr_to_slice = self.val.address.cast(gdb.lookup_type("usize").pointer())
+            length = int(ptr_to_slice[1])
+            ptr = ptr_to_slice[0].cast(gdb.lookup_type("u32").pointer())
+            return codepoints_to_rust_string(ptr, length)
+        except Exception:
+            return "error reading Utf32Str:\n" + traceback.format_exc()
+
+class Utf32StringPrinter:
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        try:
+            inner = self.val['inner']
+            ptr = inner['buf']['inner']['ptr']['pointer']['pointer'].cast(gdb.lookup_type("u32").pointer())
+            len = int(inner['len'])
+            return codepoints_to_rust_string(ptr, len)
+        except Exception:
+            return "error reading Utf32String:\n" + traceback.format_exc()
+
+def widestring_pretty_printer():
+    pp = gdb.printing.RegexpCollectionPrettyPrinter("widestring-rs")
+    pp.add_printer('Utf32Str', '^&widestring::utfstr::Utf32Str$', Utf32StrPrinter)
+    pp.add_printer('Utf32String', '^widestring::utfstring::Utf32String$', Utf32StringPrinter)
+    return pp


### PR DESCRIPTION
Activate these pretty printers with "source gdb/widestring.py".  Then "p
someutf32string" will print as string instead of as opaque struct or vector
of code points.

The escaping should behave like the stdlib pretty printers (i.e. printing a
"String" object in "rust-gdb").

I added one exception: surrogate and private-use-area codepoints are printed
using rust syntax (e.g. "\u{e001}").  Per my biased opinion, this is more
useful for debugging, especially for programs like fish or Emacs that use
private-use-area codepoints for encoding.  (Though arguably, fish should
eventually have a dedicated string type for that.)  We can also remove this
exception, i.e. forward private-use-area codepoints as-is, like the stdlib
pretty printers do.

In future we should perhaps find a way to load these automatically in
"rust-gdb".  Until then, I figured this repo is the most obvious way to
share pretty printers.
